### PR TITLE
(FACT-914) Update boost 1.57

### DIFF
--- a/projects/boost/Makefile
+++ b/projects/boost/Makefile
@@ -1,4 +1,4 @@
-boost_ver=1_55_0
+boost_ver=1_57_0
 boost_=boost_$(boost_ver)
 projects+=$(boost_)
 names+=boost

--- a/projects/boost/Makefile.SunOS-i386
+++ b/projects/boost/Makefile.SunOS-i386
@@ -1,25 +1,26 @@
 
 fetched/$(boost_).tar.gz:
-	$(wget) 'http://iweb.dl.sourceforge.net/project/boost/boost/1.55.0/$(boost_).tar.gz'
+	$(wget) 'http://iweb.dl.sourceforge.net/project/boost/boost/1.57.0/$(boost_).tar.gz'
 	mv $(boost_).tar.gz $(@D)
 
 userconfig='using gcc : $(gcc_ver) : $(gccpath)/bin/$(target)-g++ : <linkflags>"-Wl,-rpath=$(gccpath)/lib" ;'
 
-build/$(arch)/$(boost_)/tools/build/v2/user-config.jam: build/$(arch)/$(boost_)/._.sync
+build/$(arch)/$(boost_)/tools/build/user-config.jam: build/$(arch)/$(boost_)/._.sync
 	echo $(userconfig) > $@
 
-build/$(arch)/$(boost_)/._.config: build/$(arch)/$(boost_)/._.sync build/$(arch)/$(boost_)/tools/build/v2/user-config.jam
-	(cd $(@D)/tools/build/v2 && env $(cmakepath) ./bootstrap.sh ) $(t) $@.log
+build/$(arch)/$(boost_)/._.config: build/$(arch)/$(boost_)/._.sync build/$(arch)/$(boost_)/tools/build/user-config.jam
+	(cd $(@D)/tools/build && env $(cmakepath) ./bootstrap.sh ) $(t) $@.log
 	touch $@
 
 build/$(arch)/$(boost_)/._.make: build/$(arch)/$(boost_)/._.config
-	(cd $(@D)/tools/build/v2 && env $(cmakepath) \
+	(cd $(@D)/tools/build && env $(cmakepath) \
 		./b2 install --prefix=$(installroot)/$(arch) toolset=gcc --debug-configuration \
 	) $(t) $@.log
 	touch $@
 
 install/$(arch)/$(boost_)/._.install: build/$(arch)/$(boost_)/._.make
-	(cd build/$(arch)/$(boost_)/ && env $(cmakepath) $(installroot)/$(arch)/bin/b2 --debug-configuration \
+	(cd build/$(arch)/$(boost_)/ && env $(cmakepath) $(installroot)/$(arch)/bin/b2 toolset=gcc define=_XOPEN_SOURCE=600 \
+		--debug-configuration \
 		--build-dir=build/$(arch)/$(boost_) \
 		--prefix=$(installroot)/$(arch) \
 		--with-filesystem \

--- a/projects/boost/Makefile.Windows_NT
+++ b/projects/boost/Makefile.Windows_NT
@@ -1,12 +1,12 @@
 ifdef BOOST_PRE
-boostfile=boost_1.55.0_mingw-w64_4.8.1.7z
+boostfile=boost_1.57.0_mingw-w64_4.8.1.7z
 fetched/$(boostfile):
 	$(wget) 'https://s3.amazonaws.com/kylo-pl-bucket/$(boostfile)'
 	$(move) $(boostfile) $(@D)
 build/$(arch)/$(boost_)/._.make: fetched/$(boostfile) | build/$(arch)
 	$(remove) build/$(arch)/$(boost_)
 	$(7z) fetched/$(boostfile) -obuild/$(arch) >NUL:
-	$(move) build/$(arch)/boost_1.55.0_mingw-w64_4.8.1 build/$(arch)/$(boost_)
+	$(move) build/$(arch)/boost_1.57.0_mingw-w64_4.8.1 build/$(arch)/$(boost_)
 
 install/$(arch)/$(boost_)/._.install: build/$(arch)/$(boost_)/._.make
 	$(cp) build/$(arch)/$(boost_) $(prefix)/$(boost_)
@@ -14,7 +14,7 @@ install/$(arch)/$(boost_)/._.install: build/$(arch)/$(boost_)/._.make
 else
 
 fetched/$(boost_).7z:
-	$(wget) 'http://iweb.dl.sourceforge.net/project/boost/boost/1.55.0/$(boost_).7z'
+	$(wget) 'http://iweb.dl.sourceforge.net/project/boost/boost/1.57.0/$(boost_).7z'
 	$(move) $(boost_).7z $(@D)
 
 source/$(boost_)/._.checkout: fetched/$(boost_).7z | source

--- a/projects/facter/Makefile
+++ b/projects/facter/Makefile
@@ -2,7 +2,7 @@ facter_ver=0
 facter_=facter-$(facter_ver)
 projects+=$(facter_)
 names+=facter
-facter_clone=http://github.com/puppetlabs/facter
+facter_clone=https://github.com/puppetlabs/facter
 
 $(eval $(call standard_x,$(facter_)))
 


### PR DESCRIPTION
Update Boost to 1.57 to fix boost::filesystem's dependence on
std::locale. On Solaris with GCC, std::locale is broken and this caused
an exception to be thrown unless facter is run with LC_ALL=C.

Required a minor tweak to compilation settings to build Boost 1.57 with
GCC on Solaris - Boost.Log defines _XOPEN_SOURCE=500, which is
incompatible with GCC's headers when building with c99 compatibility. We
redefine to _XOPEN_SOURCE=600, which works on Solaris 10 and 11.

Use https for Git repos, because wth weren't we?