### PR TITLE
(maint) Make dependency on Boost.Chrono explicit

### DIFF
--- a/projects/boost/Makefile.SunOS-i386
+++ b/projects/boost/Makefile.SunOS-i386
@@ -30,6 +30,7 @@ install/$(arch)/$(boost_)/._.install: build/$(arch)/$(boost_)/._.make
 		--with-system \
 		--with-thread \
 		--with-locale \
+		--with-chrono \
 		--disable-icu \
 		install \
 	) $(t) $@.log

--- a/projects/boost/Makefile.Windows_NT
+++ b/projects/boost/Makefile.Windows_NT
@@ -38,6 +38,7 @@ build/$(arch)/$(boost_)/._.make: build/$(arch)/$(boost_)/._.sync
 		--with-regex \
 		--with-log \
 		--with-locale \
+		--with-chrono \
 		boost.locale.iconv=off \
 		--prefix='"$(prefix)\$(boost_)"'
 	$(touch) $@


### PR DESCRIPTION
It's currently built automatically because it's required by log, but
with FACT-951 we have explicit dependencies on it, so make building
explicit as well.